### PR TITLE
change cluster path to relative

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,6 @@ services:
     volumes:
       - "./ASA:/usr/games/.wine/drive_c/POK/Steam/steamapps/common/ARK Survival Ascended Dedicated Server/ShooterGame"
       - "./ARK Survival Ascended Dedicated Server:/usr/games/.wine/drive_c/POK/Steam/steamapps/common/ARK Survival Ascended Dedicated Server"
-      - "/home/factorioserver/ASA_Cluster/Cluster:/usr/games/.wine/drive_c/POK/Steam/steamapps/common/ShooterGame"
+      - "./Cluster:/usr/games/.wine/drive_c/POK/Steam/steamapps/common/ShooterGame"
     memswap_limit: 16G
     mem_limit: 12G  


### PR DESCRIPTION
If copying from the docker compose the build fails because the cluster path is not relative