### PR TITLE
Fix: SteamCMD commands fix

### DIFF
--- a/scripts/install_server.sh
+++ b/scripts/install_server.sh
@@ -11,7 +11,7 @@ if [[ -z "$saved_build_id" || "$saved_build_id" != "$current_build_id" ]]; then
   echo "-----Installing ARK server-----"
   touch /home/pok/updating.flag
   echo "Current build ID is $current_build_id, initiating installation.."
-  /opt/steamcmd/steamcmd.sh +login anonymous +force_install_dir "$ASA_DIR" +app_update "$APPID" validate +quit
+  /opt/steamcmd/steamcmd.sh +force_install_dir "$ASA_DIR" +login anonymous +app_update "$APPID" validate +quit
 
   # Check for success and copy the appmanifest file
   if [[ -f "$ASA_DIR/steamapps/appmanifest_$APPID.acf" ]]; then

--- a/scripts/update_server.sh
+++ b/scripts/update_server.sh
@@ -19,7 +19,7 @@ echo "---checking for server update---"
 if server_needs_update; then
   echo "A server update is available. Updating server to build ID $current_build_id..."
   touch /home/pok/updating.flag
-  /opt/steamcmd/steamcmd.sh +login anonymous +force_install_dir "$ASA_DIR" +app_update "$APPID" +quit
+  /opt/steamcmd/steamcmd.sh +force_install_dir "$ASA_DIR" +login anonymous +app_update "$APPID" +quit
 
   # Copy the new appmanifest for future checks
   if [[ -f "$ASA_DIR/steamapps/appmanifest_$APPID.acf" ]]; then


### PR DESCRIPTION
Fixed the SteamCMD commands for the install_server.sh and update_server.sh scripts. Without the changes the container setup from the management-script doesn't work and ends up unsuccessful. force_install_dir has to be executed before login or else SteamCMD won't run the ArkServer-installation correctly.

Don't know if thats the case for everybody, but for me the script doesn't work without these changes.