### PR TITLE
Fix instance config copy empty

### DIFF
--- a/POK-manager.sh
+++ b/POK-manager.sh
@@ -1483,9 +1483,11 @@ read_docker_compose_config() {
 
   # Parse the environment section
   local env_vars
-  mapfile -t env_vars < <(yq e '.services.asaserver.environment[]' "$docker_compose_file")
+  mapfile -t env_vars < <(yq -e '.services.asaserver.environment[]' "$docker_compose_file")
 
   for env_var in "${env_vars[@]}"; do
+    env_var="${env_var%\"}"
+    env_var="${env_var#\"}"
     # Splitting each line into key and value
     IFS='=' read -r key value <<< "${env_var}"
     key="${key//-/_}" # Replace hyphens with underscores to match your script's keys
@@ -1528,7 +1530,7 @@ read_docker_compose_config() {
 
   # Separately parse the mem_limit
   local mem_limit
-  mem_limit=$(yq e '.services.asaserver.mem_limit' "$docker_compose_file")
+  mem_limit=$(yq -e '.services.asaserver.mem_limit' "$docker_compose_file")
   if [ ! -z "$mem_limit" ]; then
     # Assuming you want to strip the last character (G) and store just the numeric part
     # If you want to keep the 'G', remove the `${mem_limit%?}` manipulation


### PR DESCRIPTION
Steps to reproduce:
- Create the initial instance.
- Create another instance with ./POK-manager.sh -create instance2
- Confirm that you want to copy settings of extisting instances
- Errors due to yq syntax errors

In `read_docker_compose_config` :
https://github.com/Acekorneya/Ark-Survival-Ascended-Server/blob/1b27c0003cc75ba45114e8c6f837dd55498bb8cb/POK-manager.sh#L1486
`yq`'s parameters need `-` before use. Why using `-e` parameter at all?

Since yq returns quoted results in this form:
`"MAX_PLAYERS=70"`
We have to strip the quotes before further processing.

Thank you for your nice project.