### PR TITLE
fixes ERROR! Failed to install app '2430930' (Invalid platform)

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -782,6 +782,7 @@ steamcmd_download_to_dir() {
 
   /opt/steamcmd/steamcmd.sh \
     +force_install_dir "$target_dir" \
+    +@sSteamCmdForcePlatformType "windows" \
     +login "$USERNAME" \
     +app_update $update_args \
     +quit


### PR DESCRIPTION
Without this modification I'm getting the following error:
Logging directory: '/home/pok/.steam/steam/logs'
[  0%] Checking for available updates...
[----] Verifying installation...
UpdateUI: skip show logo
Steam Console Client (c) Valve Corporation - version 1782532820
-- type 'quit' to exit --
Loading Steam API...OK

Connecting anonymously to Steam Public...OK
Waiting for client config...OK
Waiting for user info...OK
ERROR! Failed to install app '2430930' (Invalid platform)
Unloading Steam API...OK
[ERROR] SteamCMD download failed
[ERROR] Staged installation failed
[INFO] Removing temporary download directory: /tmp/arkserver_download.CxKmmg