### PR TITLE
Upgrade container base image to Ubuntu 24.04 LTS and GE-Proton to 10-34

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,5 @@
 ## Version 2.1.81 (Latest)
+- Upgraded container base image from Ubuntu 22.04 (Jammy) to Ubuntu 24.04 LTS (Noble Numbat) and updated pinned GE-Proton from 10-33 to 10-34. This provides GLIBC 2.39, updated OpenSSL 3.0, GnuTLS 3.8, and 2024 CA certificates, resolving AsaApi plugin SSL/TLS connection failures (GitHub #135).
 - Fixed `-update` to honor the saved Docker sudo preference for image pulls and every temporary-container operation, fail promptly in unattended jobs when configured sudo authorization is unavailable, and return a failure status when SteamCMD retries are exhausted.
 - Moved multi-gigabyte SteamCMD update staging out of Docker's writable `/tmp` layer and onto `ServerFiles/arkserver/.pok-manager/update/staging`, aligning the actual download with the manager's host free-space validation while retaining explicit `TEMP_DOWNLOAD_ROOT` overrides.
 - Made automatic ARK updates a shared-installation policy: any configured `API=TRUE` or `UPDATE_SERVER=FALSE` instance now blocks automatic file replacement for every instance sharing `ServerFiles/arkserver`, while a read-only notifier reports pending manual maintenance.

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # IMPORTANT: These values are set at build time and CANNOT be changed at runtime
 # The container has fixed user IDs:
@@ -7,7 +7,7 @@ FROM ubuntu:22.04
 # Host file ownership MUST match these values to avoid permission issues
 ARG PUID=7777
 ARG PGID=7777
-ARG PROTON_VERSION=GE-Proton10-33
+ARG PROTON_VERSION=GE-Proton10-34
 
 # Set a default timezone, can be overridden at runtime
 ENV TZ=UTC
@@ -31,14 +31,14 @@ RUN set -ex; \
     tzdata locales \
     # tzdata package provides timezone database for TZ environment variable support \
     lib32gcc-s1 libglib2.0-0 libglib2.0-0:i386 libvulkan1 libvulkan1:i386 \
-    libnss3 libnss3:i386 libgconf-2-4 libgconf-2-4:i386 \
+    libnss3 libnss3:i386 \
     libfontconfig1 libfontconfig1:i386 libfreetype6 libfreetype6:i386 \
     libcups2 libcups2:i386 \
     gnupg2 ca-certificates \
     # Add X server packages for headless operation
     xvfb x11-xserver-utils xauth libgl1-mesa-dri libgl1-mesa-glx \
     # Add necessary libraries for Wine and VC++
-    libldap-2.5-0:i386 libldap-2.5-0 libgnutls30:i386 libgnutls30 \
+    libldap-2.6-0:i386 libldap-2.6-0 libgnutls30:i386 libgnutls30 \
     libxml2:i386 libxml2 libasound2:i386 libasound2 libpulse0:i386 libpulse0 \
     libopenal1:i386 libopenal1 libncurses6:i386 libncurses6 \
     # DO NOT ENABLE screen package - causes log display issues which is needed by the POK-manager.sh script
@@ -50,7 +50,7 @@ RUN set -ex; \
     # Setup WineHQ repository
     mkdir -pm755 /etc/apt/keyrings; \
     wget -O - https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key; \
-    wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources; \
+    wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources; \
     apt-get update; \
     # Install latest stable Wine
     apt-get install -y --install-recommends winehq-stable; \

--- a/test/unit/common.bats
+++ b/test/unit/common.bats
@@ -75,11 +75,11 @@ load '../test_helper/project.bash'
   run env REPO_ROOT="$PROJECT_ROOT" PROTON_ROOT="$BATS_TEST_TMPDIR/proton-valid" bash -lc '
     set -e
     source "$REPO_ROOT/scripts/common.sh"
-    mkdir -p "$PROTON_ROOT/GE-Proton10-33"
-    printf "#!/bin/bash\n" > "$PROTON_ROOT/GE-Proton10-33/proton"
-    chmod +x "$PROTON_ROOT/GE-Proton10-33/proton"
-    ln -s "$PROTON_ROOT/GE-Proton10-33" "$PROTON_ROOT/GE-Proton-Current"
-    printf "GE-Proton10-33\n" > "$PROTON_ROOT/.pok-proton-version"
+    mkdir -p "$PROTON_ROOT/GE-Proton10-34"
+    printf "#!/bin/bash\n" > "$PROTON_ROOT/GE-Proton10-34/proton"
+    chmod +x "$PROTON_ROOT/GE-Proton10-34/proton"
+    ln -s "$PROTON_ROOT/GE-Proton10-34" "$PROTON_ROOT/GE-Proton-Current"
+    printf "GE-Proton10-34\n" > "$PROTON_ROOT/.pok-proton-version"
     POK_PROTON_BASE_DIR="$PROTON_ROOT"
     resolve_pinned_proton
     printf "version=%s\n" "$POK_PROTON_VERSION"
@@ -87,8 +87,8 @@ load '../test_helper/project.bash'
   '
 
   assert_success
-  assert_output --partial "version=GE-Proton10-33"
-  assert_output --partial "/GE-Proton10-33/proton"
+  assert_output --partial "version=GE-Proton10-34"
+  assert_output --partial "/GE-Proton10-34/proton"
 }
 
 @test "resolve_pinned_proton rejects a mismatched canonical target" {
@@ -98,7 +98,7 @@ load '../test_helper/project.bash'
     printf "#!/bin/bash\n" > "$PROTON_ROOT/GE-Proton8-21/proton"
     chmod +x "$PROTON_ROOT/GE-Proton8-21/proton"
     ln -s "$PROTON_ROOT/GE-Proton8-21" "$PROTON_ROOT/GE-Proton-Current"
-    printf "GE-Proton10-33\n" > "$PROTON_ROOT/.pok-proton-version"
+    printf "GE-Proton10-34\n" > "$PROTON_ROOT/.pok-proton-version"
     POK_PROTON_BASE_DIR="$PROTON_ROOT"
     if resolve_pinned_proton; then
       echo "result=unexpected-success"

--- a/test/unit/launch_ASA.bats
+++ b/test/unit/launch_ASA.bats
@@ -23,14 +23,14 @@ load '../test_helper/project.bash'
     PROTON_RUNTIME_LOG="$BATS_TMP/proton.log"
     printf "%s\n" \
       "ProtonFixes[324] WARN: Skipping fix execution. We are probably running a unit test." \
-      "Proton: Upgrading prefix from None to GE-Proton10-33" \
+      "Proton: Upgrading prefix from None to GE-Proton10-34" \
       "wine: example actionable failure" | filter_proton_runtime_output
     printf "%s\n" "---raw-diagnostics---"
     cat "$PROTON_RUNTIME_LOG"
   '
 
   assert_success
-  assert_line "Proton: Upgrading prefix from None to GE-Proton10-33"
+  assert_line "Proton: Upgrading prefix from None to GE-Proton10-34"
   assert_line "wine: example actionable failure"
   assert_output --partial "---raw-diagnostics---"
   assert_output --partial "ProtonFixes[324] WARN: Skipping fix execution. We are probably running a unit test."


### PR DESCRIPTION
Upgrades the Docker base image to Ubuntu 24.04 LTS (Noble Numbat) and updates pinned GE-Proton to 10-34. This upgrades GLIBC to 2.39, OpenSSL to 3.0, GnuTLS to 3.8, and ca-certificates, resolving in-game plugin SSL/TLS connection failures (Fixes #135).